### PR TITLE
Update Base Image and Add PostgreSQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN set -ex \
 		gcc \
 		postgresql-dev \
 		musl-dev \
-	&& apk app --no-cache \
+	&& apk add --no-cache \
 		postgresql \
 	&& wget "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v$PGADMIN4_VERSION/pip/pgadmin4-$PGADMIN4_VERSION-py2.py3-none-any.whl" \
 	&& pip install pgadmin4-$PGADMIN4_VERSION-py2.py3-none-any.whl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN set -ex \
 		openssl \
 		gcc \
 		postgresql-dev \
-    postgresql-client \
+		postgresql \
 		musl-dev \
 	&& wget "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v$PGADMIN4_VERSION/pip/pgadmin4-$PGADMIN4_VERSION-py2.py3-none-any.whl" \
 	&& pip install pgadmin4-$PGADMIN4_VERSION-py2.py3-none-any.whl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,9 @@ RUN set -ex \
 		openssl \
 		gcc \
 		postgresql-dev \
-		postgresql \
 		musl-dev \
+	&& apk app --no-cache \
+		postgresql \
 	&& wget "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v$PGADMIN4_VERSION/pip/pgadmin4-$PGADMIN4_VERSION-py2.py3-none-any.whl" \
 	&& pip install pgadmin4-$PGADMIN4_VERSION-py2.py3-none-any.whl \
 	&& apk del .build-deps \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3-alpine3.6
 
 ENV PGADMIN4_VERSION 1.6
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.label-schema.name="pgAdmin4" \
       org.label-schema.version="$PGADMIN4_VERSION" \
       org.label-schema.license="PostgreSQL" \
       org.label-schema.url="https://www.pgadmin.org" \
-      org.label-schema.vcs-url="https://github.com/fenglc/dockercloud-pgAdmin4" 
+      org.label-schema.vcs-url="https://github.com/fenglc/dockercloud-pgAdmin4"
 
 RUN set -ex \
 	&& apk add --no-cache --virtual .run-deps \
@@ -17,6 +17,7 @@ RUN set -ex \
 		openssl \
 		gcc \
 		postgresql-dev \
+    postgresql-client \
 		musl-dev \
 	&& wget "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v$PGADMIN4_VERSION/pip/pgadmin4-$PGADMIN4_VERSION-py2.py3-none-any.whl" \
 	&& pip install pgadmin4-$PGADMIN4_VERSION-py2.py3-none-any.whl \


### PR DESCRIPTION
I've added PostgreSQL (to get pg_dump etc.) for to use backup/restore function at pgAdmin. Due to my stack's postgres version, I had to upgrade the base image to Alpine 3.6 for to get latest version of postgres tools. No error detected with python3-alpine3.6. Everything works fine now.