### PR TITLE
Use clean alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ LABEL org.label-schema.name="pgAdmin4" \
 RUN set -ex \
 	&& apk add --no-cache --virtual .run-deps \
 		bash \
+		ca-certificates \
 		postgresql \
 		postgresql-libs \
 		python3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine3.6
+FROM alpine:3.6
 
 ENV PGADMIN4_VERSION 2.1
 
@@ -14,11 +14,15 @@ RUN set -ex \
 		bash \
 		postgresql \
 		postgresql-libs \
+		python3 \
 	&& apk add --no-cache --virtual .build-deps \
 		gcc \
 		musl-dev \
 		openssl \
 		postgresql-dev \
+		python3-dev \
+	&& ln -s /usr/bin/python3 /usr/bin/python \
+	&& ln -s /usr/bin/pip3 /usr/bin/pip \
 	&& pip --no-cache-dir install \
 		flask_htmlmin \
 		https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v2.1/pip/pgadmin4-2.1-py2.py3-none-any.whl \


### PR DESCRIPTION
By changing the base image from `python:3-alpine3.6` → `alpine:3.6`,
the final resulting (uncompressed) image size is reduced from 252MB to → 221MB.

(Note: You could go one step ahead and use the newer `alpine:3.7`. This further reduces the size to 218MB. But I didn't want to mix those two issues in this pull request.)